### PR TITLE
feat: update TypeDoc workflow with branch selection and debugging

### DIFF
--- a/.github/workflows/typedoc.yml
+++ b/.github/workflows/typedoc.yml
@@ -2,6 +2,12 @@ name: TypeDoc Documentation
 
 on:
   workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to generate documentation from'
+        required: true
+        type: string
+        default: 'main'
 
 permissions:
   contents: read
@@ -15,7 +21,24 @@ jobs:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+          fetch-depth: 1
+
+      - name: Debug Directory Structure
+        run: |
+          echo "Current directory:"
+          pwd
+          echo "Directory contents:"
+          ls -la
+          echo "Packages directory contents:"
+          ls -la packages || echo "No packages directory"
+          echo "Git status:"
+          git status
+          echo "Git branch:"
+          git branch
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
@@ -40,4 +63,4 @@ jobs:
 
       - name: Deploy to GitHub Pages
         id: deployment
-        uses: actions/deploy-pages@v4 
+        uses: actions/deploy-pages@v4


### PR DESCRIPTION
Updated the TypeDoc documentation workflow with some important improvements:

Added branch selection capability through workflow_dispatch inputs, allowing us to generate documentation from any branch without needing workflow file changes
Set 'main' as the default branch
Added debugging steps to help troubleshoot deployment issues
Maintained all necessary GitHub Pages permissions and configuration

The workflow is ready for review. Once merged to main, we will be able to generate and deploy documentation from any branch through the Actions tab, making the documentation process more flexible and maintainable.