### PR TITLE
Add generate-element-schema.js

### DIFF
--- a/packages/shared-types/src/openpra-mef/technical-elements/README.md
+++ b/packages/shared-types/src/openpra-mef/technical-elements/README.md
@@ -4,6 +4,38 @@ OpenPRA technical schema is based on the latest standards for Advanced Non-Light
 
 To download the JSON Schema for technical elements, visit `/schema-download.html` when running the documentation server. The schema can be used to validate your PRA data structures and ensure compliance with the OpenPRA technical elements specification.
 
+## Table of Contents
+- [Understanding TypeScript Types and Interfaces](#understanding-typescript-types-and-interfaces)
+  - [Namespace](#namespace)
+  - [Interface](#interface)
+  - [Properties](#properties)
+  - [Variable](#variable)
+  - [Type Alias](#type-alias)
+  - [Enumeration](#enumeration)
+  - [Function](#function)
+- [Running the Documentation](#running-the-documentation)
+  - [Prerequisites](#prerequisites)
+  - [Installation](#installation)
+  - [Serving Documentation](#serving-documentation)
+- [Schema Generation](#schema-generation)
+- [Troubleshooting](#troubleshooting)
+- [Contributing](#contributing)
+  - [Reporting Issues](#reporting-issues)
+  - [Making Changes](#making-changes)
+  - [Ensuring New Files are Documented](#ensuring-new-files-are-documented)
+  - [Schema Update Guidelines](#schema-update-guidelines)
+- [Versioning](#versioning)
+  - [Version Numbers](#version-numbers)
+  - [Version Management](#version-management)
+  - [Breaking Changes](#breaking-changes)
+  - [Non-Breaking Changes](#non-breaking-changes)
+  - [Version Update Process](#version-update-process)
+- [Versioning Hierarchy](#versioning-hierarchy)
+  - [Package Version](#1-package-version-packagejson)
+  - [Schema Version](#2-schema-version-coreversionts)
+  - [Technical Element Version](#3-technical-element-version-versioninfoversion)
+  - [Version Relationships](#version-relationships)
+  - [Example Version States](#example-version-states)
 
 ## Understanding TypeScript Types and Interfaces
 
@@ -97,6 +129,31 @@ npm run serve  # Serves documentation at http://localhost:8080
 ```
 
 The documentation will be available at `http://localhost:8080`.
+
+## Schema Generation
+
+The package includes a schema generation feature that allows you to generate JSON Schema definitions for various technical elements.
+
+### Running Schema Generation
+
+To generate schemas for specific elements, use the following command:
+
+```bash
+npm run generate-schema:element -- <element-name>
+```
+
+For example:
+```bash
+npm run generate-schema:element -- event-sequence-analysis
+```
+
+If you're in the root folder (`openpra-monorepo`), you can run the command with the `--project` flag to specify the package:
+
+```bash
+npm run generate-schema:element -- --project=shared-types event-sequence-analysis
+```
+
+This will generate JSON Schema definitions for the specified element, which can be used for validation and documentation purposes.
 
 ## Troubleshooting
 

--- a/packages/shared-types/src/openpra-mef/technical-elements/index.ts
+++ b/packages/shared-types/src/openpra-mef/technical-elements/index.ts
@@ -91,20 +91,5 @@ export * as radiological_consequence_analysis from './radiological-consequence-a
 export * as integration from './integration';
 
 
-// Direct exports for commonly used integration interfaces
-export {
- OpenPSASerializable,
- OpenPSAFieldMapping,
- OpenPSASerializationOptions,
- DEFAULT_OPENPSA_SERIALIZATION_OPTIONS
-} from './integration/openPSA/openPSA-xml-serialization';
-
-
-export {
- SaphireFieldMapping,
- SaphireCompatible,
- SaphirePhase,
- phaseSaphireMappings,
- specialEventSaphireMappings
-} from './integration/SAPHIRE/saphire-annotations';
+// Direct exports removed - accessing integration types through technical_elements.integration
 

--- a/packages/shared-types/src/openpra-mef/technical-elements/integration/SAPHIRE/saphire-annotations.ts
+++ b/packages/shared-types/src/openpra-mef/technical-elements/integration/SAPHIRE/saphire-annotations.ts
@@ -1,6 +1,6 @@
 /**
  * @packageDocumentation
- * @module technical_elements.core.integration
+ * @module technical_elements.integration.SAPHIRE
  * @description SAPHIRE compatibility annotations for OpenPRA
  * @annotation Required for SAPHIRE model type differentiation (MTD format)
  * @group SAPHIRE
@@ -8,7 +8,7 @@
 
 /**
  * Represents a mapping between OpenPRA fields and SAPHIRE fields
- * @memberof technical_elements.core.integration
+ * @memberof technical_elements.integration.SAPHIRE
  * @group SAPHIRE
  */
 export interface SaphireFieldMapping {

--- a/packages/shared-types/src/openpra-mef/technical-elements/integration/index.ts
+++ b/packages/shared-types/src/openpra-mef/technical-elements/integration/index.ts
@@ -1,5 +1,6 @@
 /**
- * @module integration
+ * @packageDocumentation
+ * @module technical_elements.integration
  * @description Integration interfaces for external tools and formats
  * 
  * This module provides interfaces and types for integrating OpenPRA with 
@@ -17,7 +18,8 @@ export * from './openPSA/quantification-adapter';
 export * from './openPSA/quantification-adapter-types';
 export * from './openPSA/scram-quantification-input';
 
-// Re-export specific SAPHIRE types for convenience
+// Re-export specific SAPHIRE types for convenience within the integration namespace
+// These will be documented within the integration namespace in TypeDoc
 export {
   SaphireFieldMapping,
   SaphireCompatible,

--- a/packages/shared-types/src/openpra-mef/technical-elements/integration/openPSA/openPSA-xml-serialization.ts
+++ b/packages/shared-types/src/openpra-mef/technical-elements/integration/openPSA/openPSA-xml-serialization.ts
@@ -1,5 +1,6 @@
 /**
- * @module open_psa_serialization
+ * @packageDocumentation
+ * @module technical_elements.integration.OpenPSA
  * @description Types and utilities for OpenPSA serialization to enable compatibility with tools that support the OpenPSA MEF standard.
  * 
  * The objectives of OpenPSA serialization ensure that:
@@ -21,6 +22,7 @@
 
 /**
  * Represents a mapping between OpenPRA fields and OpenPSA fields
+ * @memberof technical_elements.integration.OpenPSA
  * @group OpenPSA XML
  */
 export interface OpenPSAFieldMapping {
@@ -36,11 +38,13 @@ import { EventTree, EventTreeBranch, EventTreeSequence, FunctionalEvent } from "
 
 /**
  * Interface for objects that can be serialized to OpenPSA XML format.
+ * @group OpenPSA XML
  */
 export interface OpenPSASerializable {
   /**
    * Serializes the object to OpenPSA XML format.
    * @returns The XML string representation.
+   * @group OpenPSA XML
    */
   toOpenPSAXML(): string;
   

--- a/packages/shared-types/src/openpra-mef/technical-elements/integration/openPSA/quantification-adapter-types.ts
+++ b/packages/shared-types/src/openpra-mef/technical-elements/integration/openPSA/quantification-adapter-types.ts
@@ -15,11 +15,13 @@ import { DistributionType, ProbabilityModel } from '../../data-analysis/data-ana
 
 /**
  * Generic Record type with string keys and any values
+ * @group SCRAM Adapter
  */
 type StringRecord<T = any> = Record<string, T>;
 
 /**
  * Interface for basic events used by the adapter
+ * @group SCRAM Adapter
  */
 export interface SystemBasicEvent {
   id: string;
@@ -66,6 +68,7 @@ export interface SystemBasicEvent {
 
 /**
  * Interface for parameters used by the adapter
+ * @group SCRAM Adapter
  */
 export interface Parameter {
   id: string;
@@ -82,6 +85,7 @@ export interface Parameter {
 
 /**
  * Interface for components used by the adapter
+ * @group SCRAM Adapter
  */
 export interface Component {
   id: string;
@@ -111,6 +115,7 @@ export interface Component {
 
 /**
  * Interface for gates in fault trees used by the adapter
+ * @group SCRAM Adapter
  */
 export interface Gate {
   id: string;
@@ -123,6 +128,7 @@ export interface Gate {
 
 /**
  * Interface for fault trees used by the adapter
+ * @group SCRAM Adapter
  */
 export interface FaultTree {
   id: string;
@@ -138,6 +144,7 @@ export interface FaultTree {
 
 /**
  * Interface for functional events in event trees used by the adapter
+ * @group SCRAM Adapter
  */
 export interface FunctionalEvent {
   id: string;
@@ -146,6 +153,7 @@ export interface FunctionalEvent {
 
 /**
  * Interface for sequences in event trees used by the adapter
+ * @group SCRAM Adapter
  */
 export interface Sequence {
   id: string;
@@ -154,6 +162,7 @@ export interface Sequence {
 
 /**
  * Interface for event trees used by the adapter
+ * @group SCRAM Adapter
  */
 export interface EventTree {
   id: string;
@@ -168,6 +177,7 @@ export interface EventTree {
 
 /**
  * Interface for CCF group factors used by the adapter
+ * @group SCRAM Adapter
  */
 export interface CCFFactor {
   level: number;
@@ -176,6 +186,7 @@ export interface CCFFactor {
 
 /**
  * Interface for CCF group members used by the adapter
+ * @group SCRAM Adapter
  */
 export interface CCFMember {
   id: string;
@@ -183,6 +194,7 @@ export interface CCFMember {
 
 /**
  * Interface for common cause failure groups used by the adapter
+ * @group SCRAM Adapter
  */
 export interface CCFGroup {
   id: string;
@@ -231,6 +243,7 @@ export interface CCFGroup {
 /**
  * SystemsAnalysis interface used by the adapter
  * This shadows the original interface without extending it
+ * @group SCRAM Adapter
  */
 export interface SystemsAnalysis {
   // Core properties needed by the adapter
@@ -260,6 +273,7 @@ export interface SystemsAnalysis {
 /**
  * EventSequenceAnalysis interface used by the adapter
  * This shadows the original interface without extending it
+ * @group SCRAM Adapter
  */
 export interface EventSequenceAnalysis {
   // Core properties needed by the adapter
@@ -274,8 +288,9 @@ export interface EventSequenceAnalysis {
 }
 
 /**
- * InitiatingEventsAnalysis interface used by the adapter
+  *InitiatingEventsAnalysis interface used by the adapter
  * This shadows the original interface without extending it
+ * @group SCRAM Adapter
  */
 export interface InitiatingEventsAnalysis {
   id: string;
@@ -286,6 +301,7 @@ export interface InitiatingEventsAnalysis {
  * Type guard to check if an object can be used as SystemsAnalysis for the adapter
  * @param obj - Object to check
  * @returns Whether the object is compatible with the adapter's SystemsAnalysis
+ * @group SCRAM Adapter
  */
 export function isSystemsAnalysis(obj: any): obj is SystemsAnalysis {
   return obj && 
@@ -298,6 +314,7 @@ export function isSystemsAnalysis(obj: any): obj is SystemsAnalysis {
  * Type guard to check if an object can be used as EventSequenceAnalysis for the adapter
  * @param obj - Object to check
  * @returns Whether the object is compatible with the adapter's EventSequenceAnalysis
+ * @group SCRAM Adapter
  */
 export function isEventSequenceAnalysis(obj: any): obj is EventSequenceAnalysis {
   return obj && 
@@ -311,6 +328,7 @@ export function isEventSequenceAnalysis(obj: any): obj is EventSequenceAnalysis 
  * Adapter-specific type cast for SystemsAnalysis
  * @param obj - The original SystemsAnalysis object
  * @returns The object cast to the adapter's SystemsAnalysis interface
+ * @group SCRAM Adapter
  */
 export function asSystemsAnalysis(obj: CoreSystemsAnalysis): SystemsAnalysis {
   return obj as unknown as SystemsAnalysis;
@@ -320,6 +338,7 @@ export function asSystemsAnalysis(obj: CoreSystemsAnalysis): SystemsAnalysis {
  * Adapter-specific type cast for EventSequenceAnalysis
  * @param obj - The original EventSequenceAnalysis object
  * @returns The object cast to the adapter's EventSequenceAnalysis interface
+ * @group SCRAM Adapter
  */
 export function asEventSequenceAnalysis(obj: CoreEventSequenceAnalysis): EventSequenceAnalysis {
   return obj as unknown as EventSequenceAnalysis;
@@ -329,6 +348,7 @@ export function asEventSequenceAnalysis(obj: CoreEventSequenceAnalysis): EventSe
  * Adapter-specific type cast for InitiatingEventsAnalysis
  * @param obj - The original InitiatingEventsAnalysis object
  * @returns The object cast to the adapter's InitiatingEventsAnalysis interface
+ * @group SCRAM Adapter
  */
 export function asInitiatingEventsAnalysis(obj: CoreInitiatingEventsAnalysis): InitiatingEventsAnalysis {
   return obj as unknown as InitiatingEventsAnalysis;
@@ -340,6 +360,7 @@ export function asInitiatingEventsAnalysis(obj: CoreInitiatingEventsAnalysis): I
  * @param key - The property key
  * @param defaultValue - Default value if property doesn't exist
  * @returns The property value or default value
+ * @group SCRAM Adapter
  */
 export function safeGet<T>(obj: any, key: string, defaultValue: T): T {
   if (obj && typeof obj === 'object' && key in obj) {
@@ -352,6 +373,7 @@ export function safeGet<T>(obj: any, key: string, defaultValue: T): T {
  * Helper function to safely convert a possibly undefined object to a record
  * @param obj - The object to convert
  * @returns The object as a record or an empty object
+ * @group SCRAM Adapter
  */
 export function asRecord<T = any>(obj: any): Record<string, T> {
   if (obj && typeof obj === 'object') {

--- a/packages/shared-types/src/openpra-mef/technical-elements/integration/openPSA/quantification-adapter.ts
+++ b/packages/shared-types/src/openpra-mef/technical-elements/integration/openPSA/quantification-adapter.ts
@@ -30,6 +30,7 @@ import {
 
 /**
  * Configuration options for the quantification adapter
+ * @group SCRAM Adapter
  */
 export interface QuantificationAdapterOptions {
   /**
@@ -65,6 +66,7 @@ export interface QuantificationAdapterOptions {
 
 /**
  * Default options for the quantification adapter
+ * @group SCRAM Adapter
  */
 const DEFAULT_ADAPTER_OPTIONS: QuantificationAdapterOptions = {
   includeEventTrees: true,
@@ -76,6 +78,7 @@ const DEFAULT_ADAPTER_OPTIONS: QuantificationAdapterOptions = {
 
 /**
  * Result of a conversion operation, including the converted model and any warnings
+ * @group SCRAM Adapter
  */
 export interface ConversionResult {
   /**
@@ -96,6 +99,7 @@ export interface ConversionResult {
 
 /**
  * Adapter class for converting OpenPRA models to the quantification input format
+ * @group SCRAM Adapter
  */
 export class QuantificationAdapter {
   /**
@@ -211,6 +215,7 @@ export class QuantificationAdapter {
   
   /**
    * Convert basic events from OpenPRA to the quantification input format
+   * @group SCRAM Adapter
    */
   private static convertBasicEvents(
     systemsAnalysis: SystemsAnalysis,
@@ -302,6 +307,7 @@ export class QuantificationAdapter {
   
   /**
    * Convert house events from OpenPRA to the quantification input format
+   * @group SCRAM Adapter
    */
   private static convertHouseEvents(
     systemsAnalysis: SystemsAnalysis,
@@ -324,6 +330,7 @@ export class QuantificationAdapter {
   
   /**
    * Convert parameters from OpenPRA to the quantification input format
+   * @group SCRAM Adapter
    */
   private static convertParameters(
     systemsAnalysis: SystemsAnalysis,
@@ -412,6 +419,7 @@ export class QuantificationAdapter {
   
   /**
    * Convert gates from OpenPRA fault tree to the quantification input format
+   * @group SCRAM Adapter
    */
   private static convertGates(
     faultTree: any,

--- a/packages/shared-types/src/openpra-mef/technical-elements/integration/openPSA/scram-quantification-input.ts
+++ b/packages/shared-types/src/openpra-mef/technical-elements/integration/openPSA/scram-quantification-input.ts
@@ -2559,6 +2559,7 @@ interface RuleDefinition extends BaseElement {
  *   ]
  * };
  * ```
+ * @group SCRAM Adapter
  */
 export interface QuantificationInput {
   /**

--- a/packages/shared-types/src/openpra-mef/technical-elements/scripts/check-version.js
+++ b/packages/shared-types/src/openpra-mef/technical-elements/scripts/check-version.js
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const packageJson = JSON.parse(readFileSync(join(process.cwd(), 'package.json'), 'utf8'));
+const currentVersion = packageJson.version;
+
+console.log('Checking version consistency...');
+
+// Check if version follows semantic versioning
+const semverRegex = /^\d+\.\d+\.\d+$/;
+if (!semverRegex.test(currentVersion)) {
+    console.error('❌ Version does not follow semantic versioning format (X.Y.Z)');
+    process.exit(1);
+}
+
+// Check if version in CHANGELOG.md matches
+try {
+    const changelog = readFileSync(join(process.cwd(), 'CHANGELOG.md'), 'utf8');
+    const latestVersionMatch = changelog.match(/\[(\d+\.\d+\.\d+)\]/);
+    
+    if (!latestVersionMatch || latestVersionMatch[1] !== currentVersion) {
+        console.error('❌ Version in CHANGELOG.md does not match package.json');
+        console.error(`CHANGELOG.md: ${latestVersionMatch ? latestVersionMatch[1] : 'not found'}`);
+        console.error(`package.json: ${currentVersion}`);
+        process.exit(1);
+    }
+} catch (error) {
+    console.error('❌ Could not read CHANGELOG.md');
+    process.exit(1);
+}
+
+console.log('✅ Version consistency check passed');
+console.log(`Current version: ${currentVersion}`); 

--- a/packages/shared-types/src/openpra-mef/technical-elements/scripts/generate-element-schema.js
+++ b/packages/shared-types/src/openpra-mef/technical-elements/scripts/generate-element-schema.js
@@ -1,0 +1,58 @@
+#!/usr/bin/env node
+
+import { execSync } from 'child_process';
+import fs from 'fs';
+import path from 'path';
+
+// Get the element name from command line arguments
+const element = process.argv[2];
+
+if (!element) {
+    console.error('Please specify a technical element name');
+    process.exit(1);
+}
+
+// Validate element name against known elements
+const validElements = [
+    'core',
+    'systems-analysis',
+    'event-sequence-analysis',
+    'data-analysis',
+    'plant-operating-states-analysis',
+    'initiating-event-analysis',
+    'risk-integration',
+    'success-criteria',
+    'event-sequence-quantification',
+    'mechanistic-source-term',
+    'radiological-consequence-analysis',
+    'integration'
+];
+
+if (!validElements.includes(element)) {
+    console.error(`Invalid element name. Valid elements are: ${validElements.join(', ')}`);
+    process.exit(1);
+}
+
+// Create output directory if it doesn't exist
+const outputDir = path.join(process.cwd(), 'docs', 'json-schemas');
+if (!fs.existsSync(outputDir)) {
+    fs.mkdirSync(outputDir, { recursive: true });
+}
+
+// Generate schema for the specified element
+try {
+    const outputFile = path.join(outputDir, `${element}.json`);
+    
+    // The correct format for typescript-json-schema:
+    // First arg: tsconfig path or source files
+    // Second arg: type name (* for all types)
+    // The --include option limits which files are parsed
+    const command = `npx typescript-json-schema tsconfig.json "*" --include "${element}/**/*.ts" --out ${outputFile} --required --strictNullChecks --refs`;
+    
+    console.log(`Generating schema for ${element}...`);
+    execSync(command, { stdio: 'inherit' });
+    console.log(`Schema generated successfully for ${element}`);
+} catch (error) {
+    console.error(`Error generating schema for ${element}:`, error);
+    process.exit(1);
+} 

--- a/packages/shared-types/src/openpra-mef/technical-elements/test-docs.sh
+++ b/packages/shared-types/src/openpra-mef/technical-elements/test-docs.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Test script for verifying documentation consistency
+
+echo "Cleaning docs directory..."
+npm run clean
+
+echo "Generating documentation with updated namespaces..."
+npm run generate-typedoc
+
+echo "Creating schema directories..."
+npm run create-dirs
+
+echo "Generating schema..."
+npm run generate-schema
+
+echo "Copying schema assets..."
+npm run copy-schema
+
+echo "Copying download page..."
+npm run copy-download-page
+
+echo "Starting local server..."
+npm run serve
+
+# Documentation will be available at http://localhost:8080 

--- a/packages/shared-types/src/openpra-mef/technical-elements/typedoc.json
+++ b/packages/shared-types/src/openpra-mef/technical-elements/typedoc.json
@@ -30,12 +30,14 @@
   "groupOrder": [
     "technical_elements",
     "technical_elements.core",
+    "technical_elements.integration",
     "*"
   ],
   
   "categoryOrder": [
     "technical_elements",
     "technical_elements.core",
+    "technical_elements.integration",
     "*"
   ],
   


### PR DESCRIPTION
This small PR adds the missing generate-element-schema.js and check-version.js scripts to the technical-elements package. These scripts ensure version consistency and automate schema generation for technical elements.

Got missed in the previous PRs