### PR TITLE
Fix the main app documentation link

### DIFF
--- a/apps/frontends/web-frontend/src/welcome/topBar.tsx
+++ b/apps/frontends/web-frontend/src/welcome/topBar.tsx
@@ -17,6 +17,9 @@ function computeInitials(name: string): string {
 
 function docsUrl(): string {
   const { protocol, hostname } = window.location;
+  if (hostname === "main-dev.openpra.org") {
+    return "https://docs-dev.openpra.org";
+  }
   if (hostname.endsWith("-dev.openpra.org")) {
     return `${protocol}//${hostname.replace("-dev.openpra.org", "-docs-dev.openpra.org")}`;
   }


### PR DESCRIPTION
## Summary
- point the main web app Documentation button to https://docs-dev.openpra.org
- preserve branch-preview mapping such as revamp-dev to revamp-docs-dev
- confirm all other explicit documentation links already use the canonical docs host

## Validation
- frontend type-check
- frontend production build
- repository-wide documentation URL audit